### PR TITLE
Closes #7 Add support for Elixir Phoenix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Now when you clone and start working on a new project, you can  run `sb` to inst
 
 - [yarn](https://yarnpkg.com/) - Uses `yarn` to install dependencies and run the server and tests
 
+- [mix](https://hexdocs.pm/mix/Mix.html) - Uses `mix` install dependencies and run the console and tests
+
+- [phoenix](http://phoenixframework.org/) - Uses `mix` to run the server
+
 ## Adding new plugins
 
 Want to add support for another language or framework? [Create a script in `plugins/`](https://github.com/bkeepers/strappydoo/new/master/plugins). Here's an example for a fictional framework called `scrappy`, defined in `plugins/3-scrappy.sh`:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Now when you clone and start working on a new project, you can  run `sb` to inst
 
 - [yarn](https://yarnpkg.com/) - Uses `yarn` to install dependencies and run the server and tests
 
-- [mix](https://hexdocs.pm/mix/Mix.html) - Uses `mix` install dependencies and run the console and tests
+- [mix](https://hexdocs.pm/mix/Mix.html) - Uses `mix` to install dependencies and run the console and tests
 
 - [phoenix](http://phoenixframework.org/) - Uses `mix` to run the server
 

--- a/plugins/3-mix.sh
+++ b/plugins/3-mix.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-test -n mix.exs || return 1
+test -f mix.exs || return 1
 
 mix_bootstrap(){
   mix deps.get

--- a/plugins/3-mix.sh
+++ b/plugins/3-mix.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+test -n mix.exs || return 1
+
+mix_bootstrap(){
+  mix deps.get
+}
+
+mix_console() {
+  iex -S mix
+}
+
+mix_test() {
+  mix test
+}

--- a/plugins/3-npm.sh
+++ b/plugins/3-npm.sh
@@ -11,12 +11,9 @@ npm_bootstrap(){
 }
 
 npm_test() {
-  run npm test
+  test -n "$(grep "\"test\":" package.json)" && run npm test
 }
 
-NPM_START_SCRIPT=$(grep "\"start\":" package.json)
-test -n "$NPM_START_SCRIPT" || return 1
-
 npm_server() {
-  npm start
+  test -n "$(grep "\"start\":" package.json)" && run npm start
 }

--- a/plugins/3-npm.sh
+++ b/plugins/3-npm.sh
@@ -6,14 +6,17 @@
   test ! -f .yarnrc
 ) || return 1
 
-npm_server() {
-  run npm start
-}
-
 npm_bootstrap(){
   run npm install
 }
 
 npm_test() {
   run npm test
+}
+
+NPM_START_SCRIPT=$(grep "\"start\":" package.json)
+test -n "$NPM_START_SCRIPT" || return 1
+
+npm_server() {
+  npm start
 }

--- a/plugins/3-phoenix.sh
+++ b/plugins/3-phoenix.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+PHOENIX_DEPENDENCY=$(grep "phoenix" mix.exs)
+test -n "$PHOENIX_DEPENDENCY" || return 1
+
+phoenix_server() {
+  mix phx.server
+}


### PR DESCRIPTION
@bkeepers All the commands are working except for `strappy server`.
Phoenix projects have a `package.json` file in the top directory and so the `npm_server` command is triggered.

```
$ ls
brunch-config.js  deps     mix.lock      package-lock.json  test
_build            lib      node_modules  priv               web
config            mix.exs  package.json  README.md
```

Would it be possible to make the `npm_server` check more specific?
