### PR TITLE
Add shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+notifications:
+  disabled: true
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y shellcheck
+script: script/test

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "shellcheck"

--- a/bin/strappy
+++ b/bin/strappy
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Run with DEBUG=1 to print all executed commands
-test -z $DEBUG || set -x
+test -z "$DEBUG" || set -x
 
-plugins="$(dirname $0)/../plugins"
-progname=$(basename $0)
+plugins="$(dirname "$0")/../plugins"
+progname=$(basename "$0")
 subcommand=$1
 
 set -u # Warn when referencing an unset variable
@@ -26,24 +26,25 @@ run() {
   # Loop through all available plugins
   for path in $plugins/*.sh; do
     # Source the plugin, continue if it returns anything besides 0
-    . $path || continue
+    # shellcheck source=/dev/null
+    . "$path" || continue
 
-    plugin=$(basename $path .sh)
+    plugin=$(basename "$path" .sh)
     cmd="${plugin}_${subcommand}"
 
     # Run the command if the plugin defines a function for it
-    fn_exists $cmd && $cmd
+    fn_exists "$cmd" && $cmd
   done
 }
 
 fn_exists() {
-  declare -f -F $1 > /dev/null
+  declare -f -F "$1" > /dev/null
   return $?
 }
 
 case $subcommand in
   "bootstrap" | "server" | "test" | "console" | "setup")
-    run $subcommand
+    run "$subcommand"
     ;;
   *)
     usage

--- a/script/install
+++ b/script/install
@@ -1,12 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-cd $(dirname $0)/..
-
+cd "$(dirname "$0")"/.. || exit
 
 target="$(pwd)/bin/strappy"
 destination="/usr/local/bin/strappy"
 
-read -d '' cmd <<-EOF
+read -rd '' cmd <<-EOF
 #!/bin/sh
 
 $target "\$@"

--- a/script/test
+++ b/script/test
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+shellcheck bin/* plugins/* script/*

--- a/script/test
+++ b/script/test
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -e
 
 shellcheck bin/* plugins/* script/*


### PR DESCRIPTION
This adds shellcheck as a first pass at adding some form of testing. This would have exposed the issues in #5 because it pointed out that `read` and `declare` are not available in `sh`.