### PR TITLE
Add yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ Now when you clone and start working on a new project, you can  run `sb` to inst
 
 - [dotnet](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x) - Uses `dotnet` CLI to restore dependencies and run the server and tests
 
-- [npm](https://www.npmjs.com/) - Runs `npm install` to install dependencies during `bootstrap`
+- [npm](https://www.npmjs.com/) - Runs `npm` to install dependencies and run the server and tests
 
 - [rails](http://rubyonrails.org/) - Uses `bin/rails` to run the server, tests, and console
+
+- [yarn](https://yarnpkg.com/) - Uses `yarn` to install dependencies and run the server and tests
 
 ## Adding new plugins
 

--- a/plugins/3-npm.sh
+++ b/plugins/3-npm.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-test -f package.json || return 1
+(
+  test -f package.json &&
+  test ! -f yarn.lock &&
+  test ! -f .yarnrc
+) || return 1
 
 npm_server() {
   run npm start

--- a/plugins/3-yarn.sh
+++ b/plugins/3-yarn.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+test -f yarn.lock || test -f .yarnrc || return 1
+
+yarn_server() {
+  run yarn run start
+}
+
+yarn_bootstrap(){
+  run yarn install
+}
+
+yarn_test() {
+  run yarn run test
+}


### PR DESCRIPTION
Uses yarn instead of npm if `yarn.lock` or `.yarnrc` exist.