### PR TITLE
Add Laravel and PHPUnit Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Now when you clone and start working on a new project, you can  run `sb` to inst
 
 - [composer](https://getcomposer.org/) - Installs PHP dependencies declared in `composer.json` during `bootstrap`
 
+- [laravel](https://laravel.com/) - Uses `artisan` to run the server and console. Uses `vendor/bin/phpunit` to run tests
+
 ## Adding new plugins
 
 Want to add support for another language or framework? [Create a script in `plugins/`](https://github.com/bkeepers/strappydoo/new/master/plugins). Here's an example for a fictional framework called `shaggy`, defined in `plugins/3-shaggy.sh`:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Now when you clone and start working on a new project, you can  run `sb` to inst
 
 - [composer](https://getcomposer.org/) - Installs PHP dependencies declared in `composer.json` during `bootstrap`
 
-- [laravel](https://laravel.com/) - Uses `artisan` to run the server and console. Uses `vendor/bin/phpunit` to run tests
+- [laravel](https://laravel.com/) - Uses `artisan` to run the server and console
+
+- [phpunit](https://phpunit.de/) - Uses `vendor/bin/phpunit` to run tests
 
 ## Adding new plugins
 

--- a/plugins/3-laravel.sh
+++ b/plugins/3-laravel.sh
@@ -9,7 +9,3 @@ laravel_console() {
 laravel_server() {
   run php artisan serve
 }
-
-laravel_test() {
-  run vendor/bin/phpunit
-}

--- a/plugins/3-laravel.sh
+++ b/plugins/3-laravel.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+test -f artisan || return 1
+
+laravel_console() {
+  run php artisan tinker
+}
+
+laravel_server() {
+  run php artisan serve
+}
+
+laravel_test() {
+  run vendor/bin/phpunit
+}

--- a/plugins/3-phpunit.sh
+++ b/plugins/3-phpunit.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+test -f phpunit.xml || test -f vendor/bin/phpunit || return 1
+
+phpunit_test() {
+  run vendor/bin/phpunit
+}


### PR DESCRIPTION
Dependency management is done through composer, which is already covered.

# Laravel
Console: `php artisan tinker`
Server: `php artisan serve`

# PHPUnit
Test: `vendor/bin/phpunit`